### PR TITLE
无法选择0颗星星

### DIFF
--- a/FMLStarViewDemo/FMLStarView/FMLStarView.m
+++ b/FMLStarViewDemo/FMLStarView/FMLStarView.m
@@ -60,8 +60,8 @@ static NSString * const kStarImageStyleHighlight = @"star_yellow.png";
     else {
         _currentScore = self.currentScore;
     }
-    
-    CGFloat scorePercent = self.currentScore / self.totalScore;
+    CGFloat scorePercent = 0.0f;
+    scorePercent = self.currentScore / self.totalScore;
     if (self.isFullStarLimited == YES) {
         scorePercent = [self changeToCompleteStar:scorePercent];
     }
@@ -117,7 +117,10 @@ static NSString * const kStarImageStyleHighlight = @"star_yellow.png";
 }
 
 - (CGFloat)changeToCompleteStar:(CGFloat)percent {
-    if (percent <= 0.2) {
+    if (percent <= 0.08) {
+        percent = 0.0;
+    }
+    else if (percent > 0.08 &&percent <= 0.2) {
         percent = 0.2;
     }
     else if (percent > 0.2 && percent <= 0.4) {
@@ -134,6 +137,8 @@ static NSString * const kStarImageStyleHighlight = @"star_yellow.png";
     }
     return percent;
 }
+
+
 
 #pragma mark - Accessor
 


### PR DESCRIPTION
bug:初始化之后，在`isFullStarLimited =YES;`的情况下默认会有一颗星被选中，但是用户无法选择取消选中这一颗星星，也就是不能提交0分的评价。
fixed:通过一种简陋的方式，通过简单的测试